### PR TITLE
does not overwrite existing keys when cloning a locale

### DIFF
--- a/bin/vue3-i18n-service.js
+++ b/bin/vue3-i18n-service.js
@@ -36,7 +36,10 @@ function createLocale (newLocale, extendedLocale) {
         .filter(block => block.type === 'i18n')
         .forEach(block => {
           let content = JSON.parse(block.content)
-          content[newLocale] = content[extendedLocale]
+          Object.entries(content[extendedLocale]).forEach(([k, v]) => {
+            if ( !content[newLocale][k] )
+              content[newLocale][k] = v
+          })
           out[file] = content
         })
     })


### PR DESCRIPTION
When cloning an existing locale to a new locale, everything is good because you have to add all keys from the existing to the new one.

But let's assume a case were a locale is not fully translated, you could have some missing keys. If you use the `¢reate` command, you'll overwrite ALL existing translations with the ones from the source locale.

With this PR, only missing keys are added, existing one doesn't get touch.